### PR TITLE
Fix Homebrew formula CI for tap-only installs

### DIFF
--- a/.github/workflows/homebrew.yaml
+++ b/.github/workflows/homebrew.yaml
@@ -8,16 +8,16 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Set up Homebrew
+      - name: Create Test Tap
         run: |
-          brew update
-          brew tap homebrew/core
+          brew tap-new codefly-dev/ci
+          cp codefly.rb "$(brew --repository codefly-dev/ci)/Formula/codefly.rb"
 
       - name: Test Formula
         run: |
-          brew install --build-from-source --verbose ./codefly.rb
+          brew install --build-from-source --verbose codefly-dev/ci/codefly
 
       - name: Test Binary
         run: |


### PR DESCRIPTION
Homebrew 6 rejects formula paths outside a tap, which has left every formula release red. Create an isolated CI tap, copy the checked-out formula into it, and install through the fully-qualified tap name. Also pin checkout to the audited v4.2.2 commit.\n\nValidated locally with `ruby -c codefly.rb`, `actionlint .github/workflows/homebrew.yaml`, and `git diff --check`.